### PR TITLE
Fix typo in command-line help

### DIFF
--- a/arm.js
+++ b/arm.js
@@ -560,7 +560,7 @@ program
 
 program
   .command('status')
-  .description('show comcise status for each repo in the forest')
+  .description('show concise status for each repo in the forest')
   .action(() => {
     gRecognisedCommand = true;
     doStatus();


### PR DESCRIPTION
I'm guessing merges to develop are the right place :)
