### PR TITLE
Discussion: Update usage text for `for-each` and `for-free`

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -209,8 +209,8 @@ program
 program
   .command("for-each")
   .alias("forEach")
-  .description("run specified command on each repo in the forest, e.g. \"fab for-each ls -- -al\"")
-  .arguments("<command> [args...]")
+  .description("run specified command on each repo in the forest, e.g. \"fab for-each -- ls -al\"")
+  .arguments("-- <command> [args...]")
   .option("-k, --keepgoing", "ignore intermediate errors and process all the repos")
   .action((command, args, options) => {
     coreFor.doForEach(command, args, options);
@@ -219,7 +219,7 @@ program
 program
   .command("for-free")
   .description("run specified command on repos which are not locked or pinned")
-  .arguments("<command> [args...]")
+  .arguments("-- <command> [args...]")
   .option("-k, --keepgoing", "ignore intermediate errors and process all the repos")
   .action((command, args, options) => {
     options.freeOnly = true; // Sticking in our own option!


### PR DESCRIPTION
If you don't need to pass `[args...]` to the `<command>` then `--` isn't needed. However as soon as you do then the position of `[args...]` and fab's own options start to get muddled. e.g. how do you know (2) will work but not (1)?
1. `fab for-each --keepoing ls -al`
2. `fab for-each ls --keepgoing -- -al`

I think it's more consistent (even thought it's sometimes unnecessary) to always advice the user to use the `--`

This PR is a proposal, I could be convinced that it's good the way it is.