### PR TITLE
Fix license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tsc": "tsc"
   },
   "author": "John Gee",
-  "license": "ISC",
+  "license": "MIT",
   "files": [
     "dist/command.js",
     "dist/src/*"


### PR DESCRIPTION
The license was appearing incorrectly here: https://libraries.io/npm/@shadowspawn%2Fforest-arborist which pulls info from package.json