### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+## Issues
+
+- After an issue has been fixed, it may be assigned back to you to test
+
+## Pull Requests
+
+- Create pull requests against the `develop` branch


### PR DESCRIPTION
Users will see that there are contributing guidelines when they open an issue or pull request (https://github.com/blog/1184-contributing-guidelines)

I mainly wanted to document that pull requests should be opened against `develop`.