### PR TITLE
Don't show --keepgoing hint if the user mistypes their command

### DIFF
--- a/src/core-for.ts
+++ b/src/core-for.ts
@@ -35,7 +35,11 @@ export function doForEach(cmd: string, args: string[], options: ForOptions) {
       }
     } catch (err) {
       if (!options.keepgoing) {
-        console.log("(to keep going despite errors use \"fab for-each --keepgoing\")");
+        // Check whether the command was a typo before suggesting the --keepgoing option
+        // `execFileSync` fails with "ENOENT" when the command being run doesn't exist
+        if (err.code !== "ENOENT") {
+          console.log("(to keep going despite errors use \"fab for-each --keepgoing\")");
+        }
         throw err;
       }
       console.log(""); // blank line after command output


### PR DESCRIPTION
The first time I tested `for-each` (after `--keepgoing` was implemented) I mistyped the command I wanted to run on all the repos and fab suggested that I try out the new `--keepgoing` option.

But if fab actually failed to spawn the process then we know `--keepgoing` isn't going to help the user.